### PR TITLE
Separação do readme português e inglês

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,23 @@
   <img src="pics/Highboy_repo.png" alt="HighBoy Banner" width="1000"/>
 </p>
 
-
-
 # 📡 Firmware HighBoy (Beta)
+
+> 🌍 **Idiomas**: [🇧🇷 Português](README.md) | [🇺🇸 English](README.us.md)
 
 Este repositório contém um **firmware em desenvolvimento** para a plataforma **HighBoy**.  
 **Atenção:** este firmware está em **fase beta** e **ainda está incompleto**.
 
 ---
 
-## Alvos Oficialmente Suportados 
+## Alvos Oficialmente Suportados
+
 | ESP32-S3 |
 | -------- |
 
 ---
 
-## Estrutura do Firmware 
+## Estrutura do Firmware
 
 Diferente de exemplos básicos com um único `main.c`, este projeto utiliza uma estrutura modular organizada em **components**, que se dividem da seguinte forma:
 
@@ -46,7 +47,8 @@ Para começar um novo projeto com ESP-IDF, siga o guia oficial:
 Apesar da estrutura modular, o projeto ainda mantém uma organização compatível com o sistema de build do ESP-IDF (CMake).
 
 Exemplo de layout:
-```
+
+```bash
 ├── CMakeLists.txt
 ├── components
 │   ├── Drives
@@ -71,72 +73,3 @@ Exemplo de layout:
 Agradecemos especialmente aos parceiros que apoiam este projeto:
 
 [![PCBWay](pics/PCBway.png)](https://www.pcbway.com)
-
-
-# 📡 HighBoy Firmware (Beta)
-
-This repository contains a **firmware in development** for the **HighBoy** platform.
-**Warning:** this firmware is in its **beta phase** and is **still incomplete**.
-
----
-
-## Officially Supported Targets
-
-| ESP32-S3 |
-| -------- |
-
----
-
-## Firmware Structure
-
-Unlike basic examples with a single `main.c`, this project uses a modular structure organized into **components**, which are divided as follows:
-
-- **Drives** – Handles hardware drivers and interfaces.
-- **Services** – Implements support functionalities and auxiliary logic.
-- **Core** – Contains the system's central logic and main managers.
-- **Applications** – Specific applications that use the previous modules.
-
-This division facilitates scalability, code reuse, and firmware organization.
-
-📷 See the general project architecture:
-[![Firmware Architecture](pics/arquitetura.png)](pics/arquitetura.png)
-
----
-
-##  How to use this project
-
-We recommend that this project serves as a basis for custom projects with ESP32-S3.
-To start a new project with ESP-IDF, follow the official guide:
-🔗 [ESP-IDF Documentation - Create a new project](https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html#start-a-new-project)
-
----
-
-## Initial project structure
-
-Despite the modular structure, the project still maintains an organization compatible with the ESP-IDF build system (CMake).
-
-Example layout:
-```
-├── CMakeLists.txt
-├── components
-│   ├── Drives
-│   ├── Services
-│   ├── Core
-│   └── Applications
-├── main
-│   ├── CMakeLists.txt
-│   └── main.c
-└── README.md
-```
-
-- The project is in its **beta** phase, subject to frequent changes.
-- Contributions and feedback are welcome to evolve the project.
-
----
-
-## 🤝 Our Supporters
-
-Special thanks to the partners supporting this project:
-
-[![PCBWay](pics/PCBway.png)](https://www.pcbway.com)
-

--- a/README.us.md
+++ b/README.us.md
@@ -1,0 +1,73 @@
+<p align="center">
+  <img src="pics/Highboy_repo.png" alt="HighBoy Banner" width="1000"/>
+</p>
+
+# 📡 HighBoy Firmware (Beta)
+
+> 🌍 **Languages**: [🇧🇷 Português](README.md) | [🇺🇸 English](README.us.md)
+
+This repository contains a **firmware in development** for the **HighBoy** platform.
+**Warning:** this firmware is in its **beta phase** and is **still incomplete**.
+
+---
+
+## Officially Supported Targets
+
+| ESP32-S3 |
+| -------- |
+
+---
+
+## Firmware Structure
+
+Unlike basic examples with a single `main.c`, this project uses a modular structure organized into **components**, which are divided as follows:
+
+- **Drives** – Handles hardware drivers and interfaces.
+- **Services** – Implements support functionalities and auxiliary logic.
+- **Core** – Contains the system's central logic and main managers.
+- **Applications** – Specific applications that use the previous modules.
+
+This division facilitates scalability, code reuse, and firmware organization.
+
+📷 See the general project architecture:
+[![Firmware Architecture](pics/arquitetura.png)](pics/arquitetura.png)
+
+---
+
+## How to use this project
+
+We recommend that this project serves as a basis for custom projects with ESP32-S3.
+To start a new project with ESP-IDF, follow the official guide:
+🔗 [ESP-IDF Documentation - Create a new project](https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html#start-a-new-project)
+
+---
+
+## Initial project structure
+
+Despite the modular structure, the project still maintains an organization compatible with the ESP-IDF build system (CMake).
+
+Example layout:
+
+```bash
+├── CMakeLists.txt
+├── components
+│   ├── Drives
+│   ├── Services
+│   ├── Core
+│   └── Applications
+├── main
+│   ├── CMakeLists.txt
+│   └── main.c
+└── README.md
+```
+
+- The project is in its **beta** phase, subject to frequent changes.
+- Contributions and feedback are welcome to evolve the project.
+
+---
+
+## 🤝 Our Supporters
+
+Special thanks to the partners supporting this project:
+
+[![PCBWay](pics/PCBway.png)](https://www.pcbway.com)


### PR DESCRIPTION
## 📚 Mudanças

Esta PR implementa suporte multilíngue para a documentação do projeto, dividindo o conteúdo do README que estava em português e inglês em arquivos separados.

### O que foi feito:
- ✅ Criado arquivo `README.us.md` para versão em inglês
- ✅ Mantido `README.md` como versão principal em português
- ✅ Adicionado índice de idiomas no topo de ambos os arquivos para fácil navegação
- ✅ Removidos links duplicados no final dos arquivos
- ✅ Melhorias de formatação (adicionado `bash` aos code blocks, removido espaços em branco desnecessários)

### Estrutura final:
- `README.md` → Português (exibido na homepage do GitHub)
- `README.us.md` → English

### Benefícios:
- 📈 Melhor organização da documentação
- 🌍 Facilita expansão futura para outros idiomas
- 🎯 Padrão seguido por projetos open-source populares
- 📖 Índice de idiomas permite acesso rápido à versão desejada

Futuras adições de idiomas podem seguir o padrão `README.XX.md` onde XX é o código de idioma (ex: `README.es.md`, `README.fr.md`, etc).