### PR TITLE
fix(tools): correct format.sh path in error message

### DIFF
--- a/tools/format.sh
+++ b/tools/format.sh
@@ -44,7 +44,7 @@ if [ "$1" = "--check" ]; then
   echo "Checking $COUNT files..."
   echo "$FILES" | xargs clang-format --dry-run --Werror 2>&1
   if [ $? -ne 0 ]; then
-    echo "Formatting errors found. Run ./scripts/format.sh to fix."
+    echo "Formatting errors found. Run ./tools/format.sh to fix."
     exit 1
   fi
   echo "All files formatted correctly."


### PR DESCRIPTION
## Summary
`tools/format.sh --check` previously printed `Run ./scripts/format.sh to fix.` when formatting errors were found, but the actual script lives at `./tools/format.sh`. This one-line change fixes the error message so contributors can follow the hint.

## Test plan
- [ ] Run `./tools/format.sh --check` on a repo with a mis-formatted file and confirm the message now points to the correct path.

---
Hey maintainers — happy to be contributing to TentacleOS. If you're open to it, I'd love to be added as a contributor so I can help more directly. I have several more improvements I'd be glad to submit. Reach me on Discord: **@justme.png**