### PR TITLE
fix(about): show ESP32-P4 on P4 firmware build

### DIFF
--- a/firmware_p4/components/Applications/ui/screens/about_settings/about_settings_ui.c
+++ b/firmware_p4/components/Applications/ui/screens/about_settings/about_settings_ui.c
@@ -73,7 +73,7 @@ void ui_about_settings_open(void) {
   lv_obj_set_style_text_color(version, current_theme.text_main, 0);
 
   lv_obj_t *hardware = lv_label_create(info_box);
-  lv_label_set_text(hardware, "HW: ESP32-S3");
+  lv_label_set_text(hardware, "HW: ESP32-P4");
   lv_obj_set_style_text_color(hardware, current_theme.text_main, 0);
 
   lv_obj_t *build = lv_label_create(info_box);


### PR DESCRIPTION
## Summary
The About screen in `firmware_p4` hard-codes `HW: ESP32-S3`, which is wrong — this is the ESP32-P4 firmware tree. Every user who opens About → Settings on a P4 build currently sees the wrong chip. One-line fix.

## Location
`firmware_p4/components/Applications/ui/screens/about_settings/about_settings_ui.c:76`

## Test plan
- [ ] Flash a P4 build, open About → Settings, confirm label reads `HW: ESP32-P4`.

## Follow-ups (not in this PR)
The same screen also hard-codes `Version: DEV` and `Build: Jan 2026`. Happy to wire those to real values in a follow-up PR if maintainers want it.

---
Hey maintainers — thanks for looking! I'd love to keep contributing to TentacleOS. If you're open to it, could I be added as a contributor? I have more PRs ready to go. Reach me on Discord: **@justme.png**